### PR TITLE
About: reflect end of Microsoft tenure (Apr 2020 - Jul 2026)

### DIFF
--- a/about.md
+++ b/about.md
@@ -4,7 +4,7 @@ title: About me
 permalink: /about/
 ---
 
-My name is Xin Wang. Currently I am working for [Microsoft](http://www.microsoft.com) as a software engineer.
+My name is Xin Wang. I am a software engineer. I worked for [Microsoft](http://www.microsoft.com) from April 2020 to July 2026.
 You can learn more about me from my [LinkedIn profile](https://www.linkedin.com/in/wangxinwang/).
 
-This site shares the tips and tricks I accumlated during daily work. Hope they could be useful for someone else too.
+This site shares the tips and tricks I accumulated during daily work. Hope they could be useful for someone else too.


### PR DESCRIPTION
Updates the about page to past tense and adds the Microsoft tenure dates.

Also a silent fix of the existing 'accumlated' -> 'accumulated' typo.